### PR TITLE
Add default export for typescript

### DIFF
--- a/src/configparser.js
+++ b/src/configparser.js
@@ -287,3 +287,4 @@ function getSectionsAsString() {
 }
 
 module.exports = ConfigParser;
+module.exports.default = ConfigParser;


### PR DESCRIPTION
I have issues importing this library in my typescript project. 
```ts
import ConfigParser from "configparser";

const parser = new ConfigParser();
```

Typescript emits the following code:

```ts
new configparser_1.default()

// Output: 
// TypeError: configparser_1.default is not a constructor
// Because configparser_1.default is undefined
```

Which fails because there's no .default export. 

This PR simply adds the missing export to the javascript source.