### PR TITLE
Add support for multiline values

### DIFF
--- a/test/data/file.ini
+++ b/test/data/file.ini
@@ -41,3 +41,19 @@ file=mytextfile.txt
 key = [value]
 test = [something 1234 hello]
 [wow] = [45]
+
+[multiline_value]
+key=this is a
+  string that spans
+  multiple lines
+
+[multiline_value_with_empty_first_line]
+key=
+  this is a
+  string that spans
+  multiple lines
+
+  [indented_section_with_multiline_value]
+  key=this is yet another
+    string that spans
+    multiple lines


### PR DESCRIPTION
This PR adds support for both reading and writing multiline values.

There are multiple examples in Python's configparser docs about this scenario: https://docs.python.org/3/library/configparser.html#supported-ini-file-structure
I've tried to handle as many edge cases as I can based off of those examples. I've also added tests for a few example cases.

Fixes https://github.com/ZachPerkitny/configparser/issues/4